### PR TITLE
Fix Nix installation flow to avoid shell restart requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,35 +9,29 @@ This config assumes username `shuntaka`. Update if different.
 
 ### Installation (macOS)
 
-1. Install Xcode Command Line Tools first:
+<details>
+<summary>Xcode Command Line Tools (if not already installed)</summary>
 
-   ```bash
-   xcode-select --install
-   ```
+```bash
+xcode-select --install
+```
+</details>
 
-2. Install Homebrew:
-
-   ```bash
-   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-   ```
-
-3. Run installation script:
-   ```bash
-   bash <(curl -sSL https://raw.githubusercontent.com/shuntaka9576/dotfiles/main/install.sh)
-   ```
+Run installation script:
+```bash
+bash <(curl -sSL https://raw.githubusercontent.com/shuntaka9576/dotfiles/main/install.sh)
+```
 
 This script will:
 
 - Install Nix package manager
-- Clone this repository to `~/dotfiles`
-- Set up nix-darwin
+- Clone this repository to `~/dotfiles` (using nix-shell)
+- Set up nix-darwin with home-manager
 - Install mise tools
 
 ### Post-Installation Setup
 
 After running the installation script, complete the following steps:
-
-1. **Restart your terminal** or run `source ~/.zshrc`
 
 2. **Neovim Setup**
 


### PR DESCRIPTION
## Summary
- Eliminate the need for shell restart after Nix installation
- Reduce external dependencies by using nix-shell for git operations
- Simplify installation process

## Changes
### install.sh
- Execute Nix commands with full path (`/nix/var/nix/profiles/default/bin`)
- Use `nix-shell -p git` for clone/pull operations
- Run nix-darwin command directly instead of using make init

### README.md
- Move Xcode installation to collapsible section (optional step)
- Remove Homebrew installation step (no longer needed)
- Remove shell restart instruction after installation

## Test plan
- [ ] Verify install.sh works correctly on fresh macOS environment
- [ ] Confirm installation completes without shell restart after Nix installation
- [ ] Test update flow (git pull) works properly on existing installations