### PR TITLE
Add Mac App Store apps management to nix-darwin

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,7 @@ After running the installation script, complete the following steps:
 
 ### Manual Application Installation
 
-- Kindle
 - Happy Hacking Keyboard.app
-- CompareMerge.app
 - Testcontainers Desktop.app
 
 </details>

--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -54,6 +54,10 @@
       "screen-studio"
       "termius"
     ];
+    masApps = {
+      "Kindle" = 302584613;
+      "CompareMerge" = 478570084;
+    };
   };
 
   system.defaults = {


### PR DESCRIPTION
## Summary
- Add masApps configuration to nix-darwin for automated Mac App Store app installation
- Remove Kindle and CompareMerge from manual installation list in README

## Changes
### nix-darwin/default.nix
- Added `masApps` section with:
  - Kindle (App Store ID: 302584613)
  - CompareMerge (App Store ID: 478570084)

### README.md
- Removed Kindle and CompareMerge from "Manual Application Installation" section
- These apps are now managed automatically via nix-darwin

## Test plan
- [x] Run `sudo nix run github:LnL7/nix-darwin -- switch --flake ".#shuntaka"` to apply changes
- [x] Verify Kindle and CompareMerge are installed via Mac App Store
- [x] Confirm README accurately reflects remaining manual installations