### PR TITLE
Update development tools configuration

### DIFF
--- a/home-manager/programs/claude/settings.json
+++ b/home-manager/programs/claude/settings.json
@@ -1,11 +1,13 @@
 {
   "env": {
-    "MAX_THINKING_TOKENS": "31999"
+    "MAX_THINKING_TOKENS": "31999",
+    "DISABLE_AUTOUPDATER": "1"
   },
   "includeCoAuthoredBy": false,
   "permissions": {
     "defaultMode": "bypassPermissions"
   },
+  "model": "opus",
   "hooks": {
     "Stop": [
       {
@@ -19,5 +21,7 @@
       }
     ]
   },
-  "model": "sonnet"
+  "feedbackSurveyState": {
+    "lastShownTime": 1753950926578
+  }
 }

--- a/home-manager/programs/mise/.default-npm-packages
+++ b/home-manager/programs/mise/.default-npm-packages
@@ -3,6 +3,6 @@ lighthouse
 npm-check-updates
 @biomejs/biome
 pnpm
-@anthropic-ai/claude-code
+@anthropic-ai/claude-code@1.0.24
 typescript-language-server
 @benborla29/mcp-server-mysql

--- a/home-manager/programs/vscode/settings.json
+++ b/home-manager/programs/vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "chat.tools.autoApprove": true,
   // exclude files
   "files.exclude": {
     "**/.git": true,
@@ -221,5 +222,8 @@
   "terminal.integrated.env.osx": {
     "Q_NEW_SESSION": "1"
   },
-  "kiroAgent.trustedCommands": ["*"]
+  "kiroAgent.trustedCommands": [
+    "*"
+  ],
+  "github.copilot.nextEditSuggestions.enabled": true
 }


### PR DESCRIPTION
## Summary
- Update Claude Code settings to use Opus model and disable auto-updater
- Enable new VS Code features for chat tools and GitHub Copilot
- Pin claude-code npm package to specific version

## Detailed Changes

### Claude Code (`home-manager/programs/claude/settings.json`)
- Changed model from `sonnet` to `opus`
- Added `DISABLE_AUTOUPDATER: "1"` to environment variables
- Added feedback survey state tracking

### VS Code (`home-manager/programs/vscode/settings.json`)
- Enabled `chat.tools.autoApprove` for automatic approval of chat tool suggestions
- Enabled `github.copilot.nextEditSuggestions.enabled` for next edit suggestions feature

### mise npm packages (`home-manager/programs/mise/.default-npm-packages`)
- Pinned `@anthropic-ai/claude-code` to version `1.0.24` for version stability

## Test Plan
- [ ] Verify Claude Code launches with Opus model
- [ ] Confirm auto-updater is disabled in Claude Code
- [ ] Test VS Code chat tools auto-approve functionality
- [ ] Verify GitHub Copilot next edit suggestions work in VS Code
- [ ] Ensure mise installs the correct claude-code version

🤖 Generated with [Claude Code](https://claude.ai/code)